### PR TITLE
Avoid positional parameters in regex.sub method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 # build files
 /build/
+
+# cache files
+/windowgram/__pycache__/

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -495,7 +495,7 @@ def tmux_version(): # -> name, version
     result = [ line.strip() for line in result.split("\n") if line.strip() ]
     name = result[0].split(" ", 1)[0] # Name that was reported by tmux (should be "tmux")
     version = result[0].split(" ", 1)[1] # Only the version is needed
-    version = re.sub(r'[a-z]', '', version, re.I) # remove caracters from version (i.e: 2.9a is 2.9)
+    version = re.sub(r'[a-z]', '', version, count=re.I) # remove caracters from version (i.e: 2.9a is 2.9)
     return name, version
 
 def signal_handler_break( signal_number, frame ):

--- a/tmuxomatic
+++ b/tmuxomatic
@@ -2216,7 +2216,7 @@ def tmuxomatic( program_cli, full_cli, user_wh, session_name, session, active_se
     last_window = ""        # Recent "new-window" (changed to "select-window" on save)
     last_pane = ""          # Recent "select-pane" (unmodified)
     list_commands = [ cmd for cmdlist in list_execution for cmd in cmdlist ]
-    semicolon = " \; "
+    semicolon = " \\; "
     switch_back = semicolon + switch_back
     batch = ""
     def execute(batch, switch_back):

--- a/windowgram/windowgram.py
+++ b/windowgram/windowgram.py
@@ -1061,7 +1061,7 @@ class Windowgram():
                 elif edge[0] == w:  panes.append( windowgram_chars[y][w-1] )
                 else:               panes += [ windowgram_chars[y][edge[0]-1], windowgram_chars[y][edge[0]] ]
         else: # if axis == "h":
-            if edge[0] is not 0:    panes += [ windowgram_chars[edge[0]-1][x] for x in range(edge[1], edge[2]) ]
+            if edge[0] != 0:    panes += [ windowgram_chars[edge[0]-1][x] for x in range(edge[1], edge[2]) ]
             if edge[0] is not h:    panes += [ windowgram_chars[edge[0]  ][x] for x in range(edge[1], edge[2]) ]
         return "".join( set( panes ) )
 
@@ -2065,10 +2065,10 @@ class EdgeProcessing:
         ignore = "*@:" # The "@" is for when the parameters hint and edge are combined
         # Reduce edge and resolve hint
         swapped = ""
-        res_hint = resolve_vhtblr( hint ) if hint is not "" else ""
+        res_hint = resolve_vhtblr( hint ) if hint != "" else ""
         res_edge = thruvalid_panes( edge, ignore )
         if not res_hint or not res_edge:
-            swapped_hint = resolve_vhtblr( edge ) if edge is not "" else ""
+            swapped_hint = resolve_vhtblr( edge ) if edge != "" else ""
             swapped_edge = thruvalid_panes( hint, ignore )
             if swapped_hint and res_edge:
                 res_hint, res_edge = swapped_hint, swapped_edge
@@ -2871,7 +2871,7 @@ def cmd_drag_2(fpp_PRIVATE, hint, edge, direction, size, limit=None):
         for wgm0s, wgm0x, wgm1s, wgm1x in res_scalegroups_masks:
             # Scale this scalegroup
             def modifier(which, val, size, inv):
-                return ( val + ( -size if ( ( inv == "-" ) ^ ( which is not 0 ) ) else size ) ) if val else 0
+                return ( val + ( -size if ( ( inv == "-" ) ^ ( which != 0 ) ) else size ) ) if val else 0
             sw0, sh0 = wgm0s.Analyze_WidthHeight()
             sw1, sh1 = wgm1s.Analyze_WidthHeight()
             if res_direction == "h" and sw0: sw0 = modifier(0, sw0, count, inverse)
@@ -3298,6 +3298,3 @@ def cmd_flip(fpp_PRIVATE):
 ##
 
 # TODO
-
-
-

--- a/windowgram/windowgram_test.py
+++ b/windowgram/windowgram_test.py
@@ -157,7 +157,7 @@ class SenseTestCase(unittest.TestCase):
         for ix, (command, windowgram) in enumerate( zip( commands, windowgramgroup_list ) ):
             errors = flex_processor( wg, command, noticesok )
             self.assertTrue( not errors, errors )
-            self.assertTrue( wg.Export_String() == windowgram, 
+            self.assertTrue( wg.Export_String() == windowgram,
                 "The resulting windowgram for sequence #" + str(ix+1) + " does not match: \n\n" + wg.Export_String() )
             wlist.append( wg.Export_String() )
         pattern_produced = WindowgramGroup_Convert.List_To_Pattern( \
@@ -634,22 +634,22 @@ class Test_FlexCores(SenseTestCase):
         """ )
         status, axis, minimal, optimal = edgecore( wg, "5", "right" )
         self.assertTrue( status is EdgeStatus.Valid )
-        self.assertTrue( axis is "v" )
+        self.assertTrue( axis == "v" )
         self.assertTrue( minimal == [ [6, 1, 3] ] )
         self.assertTrue( optimal == [ [6, 1, 3] ] )
         status, axis, minimal, optimal = edgecore( wg, "0", "left" )
         self.assertTrue( status is EdgeStatus.Valid )
-        self.assertTrue( axis is "v" )
+        self.assertTrue( axis == "v" )
         self.assertTrue( minimal == [ [0, 0, 1] ] )
         self.assertTrue( optimal == [ [0, 0, 1] ] )
         status, axis, minimal, optimal = edgecore( wg, "8", "bottom" )
         self.assertTrue( status is EdgeStatus.Valid )
-        self.assertTrue( axis is "h" )
+        self.assertTrue( axis == "h" )
         self.assertTrue( minimal == [ [6, 3, 6] ] )
         self.assertTrue( optimal == [ [6, 3, 6] ] )
         status, axis, minimal, optimal = edgecore( wg, "1", "top" )
         self.assertTrue( status is EdgeStatus.Valid )
-        self.assertTrue( axis is "h" )
+        self.assertTrue( axis == "h" )
         self.assertTrue( minimal == [ [0, 1, 3] ] )
         self.assertTrue( optimal == [ [0, 1, 3] ] )
 
@@ -676,7 +676,7 @@ class Test_FlexCores(SenseTestCase):
         """ )
         status, axis, minimal, optimal = edgecore( wg, "12" )
         self.assertTrue( status is EdgeStatus.Valid )
-        self.assertTrue( axis is "v" )
+        self.assertTrue( axis == "v" )
         self.assertTrue( minimal == [ [3, 1, 2] ] )
         self.assertTrue( optimal == [ [3, 1, 2] ] )
         wg = Windowgram( """
@@ -689,7 +689,7 @@ class Test_FlexCores(SenseTestCase):
         """ )
         status, axis, minimal, optimal = edgecore( wg, "12" )
         self.assertTrue( status is EdgeStatus.Valid )
-        self.assertTrue( axis is "v" )
+        self.assertTrue( axis == "v" )
         self.assertTrue( minimal == [ [3, 2, 3] ] )
         self.assertTrue( optimal == [ [3, 0, 5] ] )
         wg = Windowgram( """
@@ -702,7 +702,7 @@ class Test_FlexCores(SenseTestCase):
         """ )
         status, axis, minimal, optimal = edgecore( wg, "12" )
         self.assertTrue( status is EdgeStatus.Valid )
-        self.assertTrue( axis is "v" )
+        self.assertTrue( axis == "v" )
         self.assertTrue( minimal == [ [3, 2, 3] ] )
         self.assertTrue( optimal == [ [3, 1, 4] ] )
 
@@ -710,11 +710,11 @@ class Test_FlexCores(SenseTestCase):
 
     def test_SmudgeCore_Basic(self):
         wg_i = Windowgram( """
-            12345 
-            abcde 
-            fghij 
-            ABCDE 
-            FGHIJ 
+            12345
+            abcde
+            fghij
+            ABCDE
+            FGHIJ
         """ )
         group_o = """
             2345 11345 1234 12355
@@ -723,11 +723,11 @@ class Test_FlexCores(SenseTestCase):
             BCDE AACDE ABCD ABCEE
             GHIJ FFHIJ FGHI FGHJJ
 
-            abcde 12345 12345 12345 
-            fghij 12345 abcde abcde 
-            ABCDE fghij fghij fghij 
-            FGHIJ ABCDE ABCDE FGHIJ 
-                  FGHIJ       FGHIJ 
+            abcde 12345 12345 12345
+            fghij 12345 abcde abcde
+            ABCDE fghij fghij fghij
+            FGHIJ ABCDE ABCDE FGHIJ
+                  FGHIJ       FGHIJ
 
             345 12345 123 12555
             cde abcde abc abeee
@@ -735,11 +735,11 @@ class Test_FlexCores(SenseTestCase):
             CDE AAADE ABC ABCDE
             HIJ FFFIJ FGH FGHIJ
 
-            fghij 12345 12345 12345 
-            ABCDE ab345 abcde abcde 
-            FGHIJ fg345 fghij FGHij 
-                  ABCDE       FGHDE 
-                  FGHIJ       FGHIJ 
+            fghij 12345 12345 12345
+            ABCDE ab345 abcde abcde
+            FGHIJ fg345 fghij FGHij
+                  ABCDE       FGHDE
+                  FGHIJ       FGHIJ
         """
         wg_o_list = WindowgramGroup_Convert.Pattern_To_List( group_o )
         wg_x_list = [
@@ -2198,6 +2198,3 @@ class Test_ReadmeDemonstrations(SenseTestCase):
             zzzzzzzzzzzzzbbbbbbbbddddddddllllllll zzzzzzzzzzzzzbbbbbbbbbbddddddddddllllllllll
             zzzzzzzzzzzzzbbbbbbbbddddddddllllllll zzzzzzzzzzzzzbbbbbbbbbbddddddddddllllllllll
         """ )
-
-
-


### PR DESCRIPTION
DeprecationWarning: 'count' is passed as positional argument 